### PR TITLE
Fix typo test case (authentication with DH keys)

### DIFF
--- a/draft-ietf-lake-edhoc.md
+++ b/draft-ietf-lake-edhoc.md
@@ -2422,7 +2422,7 @@ P_2e (CBOR Sequence) (10 bytes)
 30 48 64 21 0d 2e 18 b9 28 cd 
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-K_2e = HKDF-Expand( PRK, info, length ), where length is the length of the plaintext, so 80.
+K_2e = HKDF-Expand( PRK, info, length ), where length is the length of the plaintext, so 10.
 
 ~~~~~~~~~~~~~~~~~~~~~~~
 info for K_2e =


### PR DESCRIPTION
Description of the length for key K_2e has a typo. It states that the key should have the same length as the plaintext, which is 10 bytes long, not 80 bytes.