### PR TITLE
Update draft-ietf-lake-edhoc.md

### DIFF
--- a/draft-ietf-lake-edhoc.md
+++ b/draft-ietf-lake-edhoc.md
@@ -483,7 +483,7 @@ where label is a tstr defined by the application and length is a uint defined by
 
 where H() is the hash function in the selected cipher suite. Example use of the EDHOC-Exporter is given in Sections {{oscore}}{: format="counter"}.
 
-To provide forward secrecy in a even more efficient way than re-running EDHOC, EHDOC provides the function EHDOC-Exporter-FS. When EHDOC-Exporter-FS is called the old PRK_4x3m is deleted and the new PRk_4x3m is calculated as a "hash" of the old key using the Extract function as illustrated by the following pseudocode:
+To provide forward secrecy in an even more efficient way than re-running EDHOC, EDHOC provides the function EDHOC-Exporter-FS. When EHDOC-Exporter-FS is called the old PRK_4x3m is deleted and the new PRk_4x3m is calculated as a "hash" of the old key using the Extract function as illustrated by the following pseudocode:
 
 ~~~~~~~~~~~
    EHDOC-Exporter-FS( nonce ):

--- a/draft-ietf-lake-edhoc.md
+++ b/draft-ietf-lake-edhoc.md
@@ -483,6 +483,12 @@ where label is a tstr defined by the application and length is a uint defined by
 
 where H() is the hash function in the selected cipher suite. Example use of the EDHOC-Exporter is given in Sections {{oscore}}{: format="counter"}.
 
+To provide forward secrecy in a even more efficient way than re-running EDHOC, EHDOC provides the function EHDOC-Exporter-FS. When EHDOC-Exporter-FS is called the old PRK_4x3m is deleted and the new PRk_4x3m is calculated as a "hash" of the old key using the Extract function as illustrated by the following pseudocode:
+
+~~~~~~~~~~~
+   EHDOC-Exporter-FS( nonce ):
+      PRK_4x3m = Extract( [ "TH_4", nonce ], PRK_4x3m )
+~~~~~~~~~~~
 
 # EDHOC Authenticated with Asymmetric Keys {#asym}
 


### PR DESCRIPTION
1. Should be discussed in LAKE if this is the right approch
2. Should be discussed what the best way is to calculate the hash chain The nonce is included to make sure that the hash chain does not have short cycles.
3. It should be discussed if the nonce is provided by the application (OSCORE) or by EDHOC itself. If provided by OSCOREbis it could be a random string or a counter. If the nonce is provided by EDHOC it has to be a deterministic. E.g. a counter (or theoretically a LFSR....)