### PR TITLE
move to "main" branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))
 	git submodule update $(CLONE_ARGS) --init
 else
 	git clone -q --depth 10 $(CLONE_ARGS) \
-	    -b master https://github.com/martinthomson/i-d-template $(LIBDIR)
+	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif


### PR DESCRIPTION
git wants us to call our lead branches "main", and MT makefile now does that, so switch.
to avoid warning "rm -rf lib", and run make after.
